### PR TITLE
WIP: debug jitter for predicted entity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ features = [
     "vorbis",
     "x11",
     "bevy_gizmos",
+    "serialize",
     #"android_shared_stdcxx",
     "tonemapping_luts",
     "default_font",

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,7 @@ use crate::{
     shared::shared_config,
     world::setup_world,
 };
+use crate::shared::SharedPlugin;
 
 #[derive(States, Default, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum GameClientState {
@@ -68,7 +69,7 @@ pub fn client_app(net_config: client::NetConfig) -> App {
             .set(LogPlugin {
                 update_subscriber: None,
                 level: Level::INFO,
-                filter: "wgpu=error,symphonia_core=error,symphonia_format_ogg=error".to_string(),
+                filter: "wgpu=error,symphonia_core=error,symphonia_format_ogg=error,lightyear::client::prediction::rollback=debug".to_string(),
             }),
         // WorldPlugin,
         WorldInspectorPlugin::new(),
@@ -88,6 +89,8 @@ pub fn client_app(net_config: client::NetConfig) -> App {
         Update,
         wait_for_local_player_spawn.run_if(in_state(GameClientState::Connecting)),
     );
+
+    app.add_plugins(SharedPlugin);
 
     app
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,12 @@ fn main() {
     println!("listen_server: {:?}", cli.listen_server);
     println!("client_id: {:?}", cli.client_id);
 
-    let mut client_app = client_app(build_client_net_config(cli.client_id, "127.0.0.1:5000"));
-
     if cli.listen_server {
         let mut server_app = server_app(build_server_net_config());
-
-        std::thread::spawn(move || server_app.run());
+        server_app.run();
+    } else {
+        let mut client_app = client_app(build_client_net_config(cli.client_id, "127.0.0.1:5000"));
+        client_app.run();
     }
 
-    client_app.run();
 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -25,15 +25,6 @@ impl Plugin for MovementPlugin {
                 ..default()
             },
         ))
-        .add_plugins(PhysicsPlugins::new(FixedUpdate))
-        .insert_resource(Time::new_with(Physics::fixed_once_hz(64.0)))
-        .add_plugins(TnuaXpbd3dPlugin::new(FixedUpdate))
-        .add_plugins(TnuaControllerPlugin::new(FixedUpdate))
-        .add_plugins(TnuaCrouchEnforcerPlugin::new(FixedUpdate))
-        .add_systems(
-            FixedUpdate,
-            player_movement.in_set(TnuaUserControlsSystemSet),
-        )
         .add_systems(Update, (draw_interpolated_boxes, draw_confirmed_boxes));
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -62,6 +62,9 @@ pub enum Components {
 
     #[protocol(sync(mode = "full", lerp = "NullInterpolator"))]
     AngularVelocity(AngularVelocity),
+
+    #[protocol(sync(mode = "full", lerp = "NullInterpolator"))]
+    GlobalTransform(GlobalTransform),
 }
 
 #[derive(Channel)]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,8 +1,20 @@
+use bevy::log::{debug, info};
 use bevy::utils::Duration;
 use lightyear::shared::{
     config::{Mode, SharedConfig},
     tick_manager::TickConfig,
 };
+use bevy_xpbd_3d::prelude::*;
+use bevy::prelude::*;
+use bevy_tnua::control_helpers::TnuaCrouchEnforcerPlugin;
+use bevy_tnua::controller::{TnuaController, TnuaControllerPlugin};
+use bevy_tnua::TnuaUserControlsSystemSet;
+use bevy_tnua_xpbd3d::TnuaXpbd3dPlugin;
+use leafwing_input_manager::action_state::ActionState;
+use lightyear::prelude::*;
+use lightyear::prelude::client::{Confirmed, Rollback, RollbackState};
+use crate::movement::shared_movement_behaviour;
+use crate::protocol::*;
 
 pub const FIXED_TIMESTEP_HZ: f64 = 64.0;
 
@@ -14,5 +26,84 @@ pub fn shared_config(mode: Mode) -> SharedConfig {
             tick_duration: Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ),
         },
         mode,
+    }
+}
+
+pub struct SharedPlugin;
+
+impl Plugin for SharedPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(PhysicsPlugins::new(FixedUpdate));
+        app.insert_resource(Time::new_with(Physics::fixed_once_hz(FIXED_TIMESTEP_HZ)));
+        app.add_plugins(TnuaXpbd3dPlugin::new(FixedUpdate));
+        app.add_plugins(TnuaControllerPlugin::new(FixedUpdate));
+        app.add_plugins(TnuaCrouchEnforcerPlugin::new(FixedUpdate));
+        app.add_systems(FixedUpdate, movement.in_set(TnuaUserControlsSystemSet));
+
+        app.add_systems(FixedPostUpdate, after_physics_log);
+        app.add_systems(Last, last_log);
+    }
+}
+
+pub(crate) fn after_physics_log(
+    tick_manager: Res<TickManager>,
+    rollback: Option<Res<Rollback>>,
+    players: Query<
+        (Entity, &Position),
+    >,
+) {
+    let mut tick = tick_manager.tick();
+    if let Some(rollback) = rollback {
+        if let RollbackState::ShouldRollback { current_tick } = rollback.state {
+            tick = current_tick;
+        }
+    }
+    for (entity, position) in players.iter() {
+        info!(
+            ?tick,
+            ?entity,
+            ?position,
+            "Player after physics update"
+        );
+    }
+}
+
+pub(crate) fn last_log(
+    tick_manager: Res<TickManager>,
+    players: Query<
+        (
+            Entity,
+            &Position,
+        ),
+        (Without<Confirmed>, With<PlayerId>),
+    >,
+) {
+    let tick = tick_manager.tick();
+    for (entity, position) in players.iter() {
+        info!(?tick, ?entity, ?position, "Player LAST update");
+        info!(
+            ?tick,
+            ?entity,
+            "Player LAST update"
+        );
+    }
+}
+
+fn movement(
+    tick_manager: Res<TickManager>,
+    mut action_query: Query<
+        (
+            Entity,
+            &Position,
+            &mut TnuaController,
+            &ActionState<PlayerActions>,
+        ),
+        Or<(With<LocalPlayer>, With<Replicate>)>,
+    >,
+) {
+    for (entity, position, mut controller, action_state) in action_query.iter_mut() {
+        info!(?entity, tick = ?tick_manager.tick(), ?position, actions = ?action_state.get_pressed(), "applying movement to player");
+
+        shared_movement_behaviour(&mut controller, action_state);
     }
 }


### PR DESCRIPTION
Changes:
- move some movement-related stuff into a SharedPlugin
- added a LinkConditionerConfig to avoid running with 0 latency; it seems that prediction doesn't work well with 0 latency. I've seen logs that were saying `run rollback between tick T and T` and even `run rollback between tick T and T-1`
- add LogPlugin for client and server, and enable lightyear's rollback logs
- add some logs about the position of entities after the PhysicsPlugin and at the end of the frame
- run client and server separately so that we can compare client and server logs more easily


Questions:
- why is there an entity created with the PlayerId component and position (0.0, 0.0, 0.0)? Is it created by tnua? I couldn't find where it gets created
- the bevy_inspector_egui seems to show that the confirmed entity has a slight LinearVelocity, that I don't see in the predicted entity. But maybe that's just because of floats?
- I can see that the first rollback already seems to fail:
  - SERVER: `Player after physics update tick=Tick(72) entity=2v1 position=Position(Vec3(0.0, 8.734312, 0.0))`
  - CLIENT: ```Rollback check: mismatch for component between predicted and confirmed 3v1 on tick Tick(71) for component Position. Current tick: Tick(82) predicted_exist=false confirmed_exist=true
  Player after physics update tick=Tick(72) entity=4v1 position=Position(Vec3(0.0, 8.742247, 0.0))```
  
We can notice that in this rollback situation; the client entity doesn't exist on the first tick received from the server (tick 71). This is because the entity is not pre-predicted (contrary to the leafwing_inputs example).
So the flow is:
- client connects, its tick jumps forward to tick 82 because the client tick is slightly in the future to the server tick
- we receive an update from the server for the tick 71
- we check for rollback by looking at the history of all the predicted components at tick 71
- we notice that the component didn't exist on the Predicted entity at tick 71, and we insert them (Position, Rotation, etc.)
- we run rollback for frames 72->82
- at frame 72 we already see a mismatch, which shouldn't be the case. The mismatch **might be because there are some components that impact the entity's position (such as Tnua components) that aren't present in the ComponentProtocol so aren't predicted!**